### PR TITLE
fix: transform character x to operator symbol x

### DIFF
--- a/packages/shared/style/style.scss
+++ b/packages/shared/style/style.scss
@@ -262,6 +262,7 @@
     font-weight: 500;
     font-family: 'Inter';
     font-style: normal;
+    font-variant-ligatures: no-contextual;
     transition: background 0.25s, color 0.25s, border-color 0.25s, opacity 0.25s;
 }
 html,


### PR DESCRIPTION
## Summary
Changed font-variant-ligatures to prevent x from becoming a symbol when placed between two numbers

### Changelog
```
- Fix transform x character into symbol
```

## Type of Change
Please select any type below that is applicable to your changes, and delete those that are not.
- [ ] __Breaking__ - any change that would cause existing functionality to not work as expected
- [ ] __Chore__ - refactoring, build scripts or anything else that isn't user-facing
- [ ] __Docs__ - changes to the documentation
- [X] __Fix__ - a change which fixes an issue
- [ ] __New__ - a change which implements a new feature
- [ ] __Update__ - a change which updates existing functionality

## Testing
### Platforms
Please select any platforms where your changes have been tested.
- __Desktop__
	- [ ] MacOS
	- [X] Linux
	- [ ] Windows
- __Mobile__
	- [ ] iOS
	- [ ] Android
